### PR TITLE
Add facebook and chiasenhac #28 #29

### DIFF
--- a/chiasenhac/chiasenhac.go
+++ b/chiasenhac/chiasenhac.go
@@ -1,0 +1,33 @@
+package chiasenhac
+
+import (
+	"errors"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+type ChiaSeNhac struct {
+}
+
+func (csn *ChiaSeNhac) GetDirectLink(link string) ([]string, error) {
+	if link == "" {
+		return nil, errors.New("Empty Link")
+	}
+
+	var listStream []string
+
+	linkDownloadSong := link[:len(link)-5] + "_download" + link[len(link)-5:]
+
+	doc, err := goquery.NewDocument(linkDownloadSong)
+	if err != nil {
+		return nil, err
+	}
+
+	doc.Find("#downloadlink").Find("a").Each(func(i int, s *goquery.Selection) {
+		if i == 1 {
+			a, _ := s.Attr("href")
+			listStream = append(listStream, a)
+		}
+	})
+	return listStream, nil
+}

--- a/chiasenhac/chiasenhac_test.go
+++ b/chiasenhac/chiasenhac_test.go
@@ -1,0 +1,19 @@
+package chiasenhac
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var csn ChiaSeNhac
+
+func TestLinkEmptyString(t *testing.T) {
+	_, err := csn.GetDirectLink("")
+	assert.Equal(t, "Empty Link", err.Error())
+}
+
+func TestDownload(t *testing.T) {
+	_, err := csn.GetDirectLink("http://chiasenhac.com/nhac-hot-2/we-dont-talk-anymore~charlie-puth-selena-gomez~1621445.html")
+	assert.Nil(t, err, "We are expecting nil error here")
+}

--- a/facebook/facebook.go
+++ b/facebook/facebook.go
@@ -1,0 +1,46 @@
+package facebook
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type Facebook struct {
+}
+
+func (fb *Facebook) GetDirectLink(link string) ([]string, error) {
+	if link == "" {
+		return nil, errors.New("Empty Link")
+	}
+	var listStream []string
+
+	response, err := http.Get(link)
+	if err != nil {
+		fmt.Println("Link is invalid")
+		return nil, err
+	}
+	defer response.Body.Close()
+	buffer, _ := ioutil.ReadAll(response.Body)
+
+	parseString := string(buffer)
+	if !strings.Contains(parseString, "sd_src") {
+		return nil, errors.New("This is private video or invalid link")
+	}
+	splitSrcSdSource := strings.Split(parseString, "sd_src")
+
+	splitLinkNotSanitize := strings.Split(splitSrcSdSource[len(splitSrcSdSource)-1], "hd_tag")
+
+	linkShort := splitLinkNotSanitize[0]
+
+	linkShort = linkShort[3 : len(linkShort)-3]
+
+	linkSanitized := strings.Replace(linkShort, "\\/", "/", -1)
+
+	listStream = append(listStream, linkSanitized)
+
+	return listStream, nil
+
+}

--- a/facebook/facebook_test.go
+++ b/facebook/facebook_test.go
@@ -1,0 +1,19 @@
+package facebook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var fb Facebook
+
+func TestLinkEmptyString(t *testing.T) {
+	_, err := fb.GetDirectLink("")
+	assert.Equal(t, "Empty Link", err.Error())
+}
+
+func TestDownload(t *testing.T) {
+	_, err := fb.GetDirectLink("https://www.facebook.com/pokerorganization/videos/508013846071164/")
+	assert.Nil(t, err, "We are expecting nil error here")
+}

--- a/zing/zing.go
+++ b/zing/zing.go
@@ -28,7 +28,6 @@ func (z *Zing) GetDirectLink(link string) ([]string, error) {
 	var listStream []string
 	if strings.Contains(link, song) {
 
-		fmt.Println(len(strings.Split(link, "/")))
 		if len(strings.Split(link, "/")) < 6 {
 			return nil, errors.New("Invalid link")
 		}


### PR DESCRIPTION
#### Status

READY

#### What's this PR do?
Add supported site to download:
- Facebook
- chiasenhac.com

#### Where should the reviewer start?
2 folders added are facebook and chiasenhac. Source code implementation and source code for testing both locate there.

#### How should this be manually tested?
Using [glod-cli](https://github.com/dwarvesf/glod-cli) to download any video and song from facebook.com and chiasenhac.com
#### Any background context you want to provide?
 Just Go
#### What are the relevant Git tickets?
#28 #29
#### Screenshots (if appropriate)
![screen shot 2016-03-09 at 11 39 14 pm](https://cloud.githubusercontent.com/assets/6028744/13642756/59803fa0-e650-11e5-94ed-4bfc6b7dd074.png)
![screen shot 2016-03-09 at 11 42 10 pm](https://cloud.githubusercontent.com/assets/6028744/13642827/985cc25c-e650-11e5-885a-933a7379b92f.png)

#### Questions:

- Is there a blog post?
- Does the knowledge base need an update?
- Does this add new dependencies which need to be added to?